### PR TITLE
[FEAT/#10] 공통 컴포넌트 버튼 구현

### DIFF
--- a/app/src/main/java/org/sopt/alami/core/designsystem/component/AlamiButton.kt
+++ b/app/src/main/java/org/sopt/alami/core/designsystem/component/AlamiButton.kt
@@ -90,5 +90,4 @@ private fun AlamiButtonPreview() {
             )
         }
     }
-
 }

--- a/app/src/main/java/org/sopt/alami/core/designsystem/component/AlamiButton.kt
+++ b/app/src/main/java/org/sopt/alami/core/designsystem/component/AlamiButton.kt
@@ -1,0 +1,94 @@
+package org.sopt.alami.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.sopt.alami.core.designsystem.theme.AlamiTheme
+import org.sopt.alami.core.designsystem.theme.AlarmiTheme
+import timber.log.Timber
+
+@Composable
+fun AlamiButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    verticalPadding: Dp = 16.dp,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() }
+) {
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val alamiColors = AlarmiTheme.colors
+    val backgroundColor = remember(isPressed) {
+        when {
+            isPressed -> alamiColors.redSecondary
+            else -> alamiColors.redPrimary
+        }
+    }
+
+    val buttonTextColor = remember(isPressed) {
+        when {
+            isPressed -> alamiColors.redThird
+            else -> alamiColors.white
+        }
+    }
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            )
+            .background(backgroundColor)
+            .padding(vertical = verticalPadding),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = text,
+            style = AlarmiTheme.typography.body01b15,
+            color = buttonTextColor
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AlamiButtonPreview() {
+    AlamiTheme {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            modifier = Modifier.padding(horizontal = 20.dp)
+        ) {
+            AlamiButton(
+                text = "알람끄기",
+                onClick = {},
+                verticalPadding = 24.dp
+            )
+
+            AlamiButton(
+                text = "저장",
+                onClick = {}
+            )
+        }
+    }
+
+}

--- a/app/src/main/java/org/sopt/alami/core/designsystem/component/AlamiButton.kt
+++ b/app/src/main/java/org/sopt/alami/core/designsystem/component/AlamiButton.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import org.sopt.alami.core.designsystem.theme.AlamiTheme
 import org.sopt.alami.core.designsystem.theme.AlarmiTheme
-import timber.log.Timber
 
 @Composable
 fun AlamiButton(


### PR DESCRIPTION
## Related issue 🛠
- closed #10 

## Work Description ✏️
- 알람 설정, 알람 끄기 화면에서 사용되는 버튼 구현

## Screenshot 📸

https://github.com/user-attachments/assets/0c943d7d-5a23-44c2-a6d2-a6103491e520

## To Reviewers 📢
제가 만들었어요~